### PR TITLE
Update package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "dms-ui",
+	"name": "stage",
 	"version": "1.1.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "dms-ui",
+			"name": "stage",
 			"version": "1.1.3",
 			"dependencies": {
 				"@emotion/react": "^11.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "stage",
+	"name": "@overture-stack/stage",
 	"version": "1.1.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "stage",
+			"name": "@overture-stack/stage",
 			"version": "1.1.3",
 			"dependencies": {
 				"@emotion/react": "^11.9.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "dms-ui",
+	"name": "stage",
 	"version": "1.1.3",
 	"private": true,
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "stage",
+	"name": "@overture-stack/stage",
 	"version": "1.1.3",
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
rename package and package-lock to correct name 
"dms-ui" => "stage"

This is **_not_** a published npm package and relies on the end user cloning the repo to use. Therefore I don't foresee any impact in this renaming and consider it a cosmetic change.