### PR TITLE
Refresh keycloak access token

### DIFF
--- a/global/utils/keycloakUtils.ts
+++ b/global/utils/keycloakUtils.ts
@@ -57,9 +57,7 @@ export const refreshAccessToken = async (refreshToken: string) => {
 		if (response.ok) {
 			return await response.json();
 		}
-		return;
 	} catch (error) {
 		console.error('Error during token refresh:', error);
-		return;
 	}
 };

--- a/global/utils/keycloakUtils.ts
+++ b/global/utils/keycloakUtils.ts
@@ -1,6 +1,13 @@
 import { getConfig } from '@/global/config';
+import urlJoin from 'url-join';
 
-const { NEXT_PUBLIC_KEYCLOAK_PERMISSION_AUDIENCE } = getConfig();
+const {
+	NEXT_PUBLIC_KEYCLOAK_CLIENT_ID,
+	KEYCLOAK_CLIENT_SECRET,
+	NEXT_PUBLIC_KEYCLOAK_PERMISSION_AUDIENCE,
+	NEXT_PUBLIC_KEYCLOAK_HOST,
+	NEXT_PUBLIC_KEYCLOAK_REALM,
+} = getConfig();
 
 export const permissionBodyParams = () => {
 	return new URLSearchParams({
@@ -20,4 +27,39 @@ export const scopesFromPermissions = (permissions: Permission[]) => {
 	return permissions
 		.filter(({ scopes }) => scopes)
 		.flatMap(({ rsname, scopes }) => scopes.flatMap((scope) => [rsname + '.' + scope]));
+};
+
+export const refreshAccessToken = async (refreshToken: string) => {
+	try {
+		const url = urlJoin(
+			NEXT_PUBLIC_KEYCLOAK_HOST,
+			`realms`,
+			NEXT_PUBLIC_KEYCLOAK_REALM,
+			'protocol/openid-connect/token',
+		);
+
+		const formData = new URLSearchParams({
+			client_id: NEXT_PUBLIC_KEYCLOAK_CLIENT_ID,
+			client_secret: KEYCLOAK_CLIENT_SECRET,
+			grant_type: 'refresh_token',
+			refresh_token: refreshToken,
+		});
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+			},
+			body: formData,
+		});
+
+		// Parse the response and return the result
+		if (response.ok) {
+			return await response.json();
+		}
+		return;
+	} catch (error) {
+		console.error('Error during token refresh:', error);
+		return;
+	}
 };

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -104,14 +104,16 @@ export const getAuthOptions = (req: GetServerSidePropsContext['req'] | NextApiRe
 						token.scopes = await fetchScopes(token.account.access_token);
 					}
 				} else {
-					const tokenExpiresAtMs = token.account.expires_at * 1000;
-					if (Date.now() >= tokenExpiresAtMs) {
-						// Access token has expired. Use the refresh token to obtain a new one.
-						const requestedNewToken = await refreshAccessToken(token.account.refresh_token);
-						token.account = {
-							...token.account,
-							...requestedNewToken,
-						};
+					if (account?.provider === AUTH_PROVIDER.KEYCLOAK) {
+						const tokenExpiresAtMs = token.account.expires_at * 1000;
+						if (Date.now() >= tokenExpiresAtMs) {
+							// Access token has expired. Use the refresh token to obtain a new one.
+							const requestedNewToken = await refreshAccessToken(token.account.refresh_token);
+							token.account = {
+								...token.account,
+								...requestedNewToken,
+							};
+						}
 					}
 				}
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -105,7 +105,7 @@ export const getAuthOptions = (req: GetServerSidePropsContext['req'] | NextApiRe
 					}
 				} else {
 					const tokenExpiresAtMs = token.account.expires_at * 1000;
-					if (Date.now() > tokenExpiresAtMs) {
+					if (Date.now() >= tokenExpiresAtMs) {
 						// Access token has expired. Use the refresh token to obtain a new one.
 						const requestedNewToken = await refreshAccessToken(token.account.refresh_token);
 						token.account = {


### PR DESCRIPTION
# Pull Request

## Description
This PR adds functionality to refresh the Keycloak access token. It automatically uses the `refresh_token` to obtain a new `access_token` when the current one expires

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Tested locally. Sign in to Stage using Keycloak user credential. Go to `Profile & Token` page and let the session still for more than 5 minutes. Hit refresh button and expect no errors on page.  Keycloak version 22

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Additional context
