### PR TITLE
refactor navbar link buttons such that they are in one component

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -28,9 +28,9 @@ import defaultTheme from './theme';
 import { OvertureLogo } from './theme/icons';
 import useAuthContext from '../global/hooks/useAuthContext';
 import { StyledLinkAsButton, InternalLink as Link } from './Link';
-import { EXPLORER_PATH, LOGIN_PATH, USER_PATH } from '../global/utils/constants';
+import { DATA_DICTIONARY_PATH, EXPLORER_PATH, LOGIN_PATH, USER_PATH } from '../global/utils/constants';
 import { getConfig } from '../global/config';
-import LinkToDataDictionary from './LinkToDataDictionary';
+import NavbarLinkButton from './NavbarLinkButton';
 
 const NavBar: React.ComponentType = () => {
 	const { user } = useAuthContext();
@@ -105,40 +105,8 @@ const NavBar: React.ComponentType = () => {
 					align-items: center;
 				`}
 			>
-				<div
-					css={(theme) => css`
-						display: flex;
-						align-items: center;
-						justify-content: center;
-						width: 144px;
-						background-color: ${theme.colors.white};
-						height: 100%;
-						&:hover {
-							background-color: ${theme.colors.grey_2};
-						}
-						border-right: 2px solid ${theme.colors.white};
-					`}
-				>
-					<Link path={EXPLORER_PATH}>
-						<a
-							css={(theme) => css`
-								display: flex;
-								flex: 1;
-								height: 100%;
-								justify-content: center;
-								align-items: center;
-								text-decoration: none;
-								color: ${theme.colors.accent_dark};
-								cursor: pointer;
-								${router.pathname === EXPLORER_PATH ? activeLinkStyle : ''}
-							`}
-						>
-							Data Explorer
-						</a>
-					</Link>
-				</div>
-
-				<LinkToDataDictionary />
+				<NavbarLinkButton path={EXPLORER_PATH} label="Data Explorer" />
+				<NavbarLinkButton path={DATA_DICTIONARY_PATH} label="Data Dictionary" />
 
 				{NEXT_PUBLIC_AUTH_PROVIDER &&
 					(user ? (

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -76,6 +76,7 @@ const NavBar: React.ComponentType = () => {
 					align-items: center;
 					margin-left: 16px;
 					cursor: pointer;
+					gap: 10px;
 				`}
 			>
 				<Link path={EXPLORER_PATH}>
@@ -98,6 +99,8 @@ const NavBar: React.ComponentType = () => {
 						</span>
 					</a>
 				</Link>
+				<NavbarLinkButton path={EXPLORER_PATH} label="Data Explorer" />
+				<NavbarLinkButton path={DATA_DICTIONARY_PATH} label="Data Dictionary" />
 			</div>
 			<div
 				css={css`
@@ -105,9 +108,6 @@ const NavBar: React.ComponentType = () => {
 					align-items: center;
 				`}
 			>
-				<NavbarLinkButton path={EXPLORER_PATH} label="Data Explorer" />
-				<NavbarLinkButton path={DATA_DICTIONARY_PATH} label="Data Dictionary" />
-
 				{NEXT_PUBLIC_AUTH_PROVIDER &&
 					(user ? (
 						<div

--- a/components/NavbarLinkButton.tsx
+++ b/components/NavbarLinkButton.tsx
@@ -21,11 +21,15 @@
 
 import { css, useTheme } from '@emotion/react';
 import { useRouter } from 'next/router';
-import { DATA_DICTIONARY_PATH } from '../global/utils/constants';
 import { InternalLink as Link } from './Link';
 import defaultTheme from './theme';
 
-const LinkToDataDictionary: React.ComponentType = () => {
+type NavbarLinkProps = {
+	path: string;
+	label: string;
+};
+
+const NavbarLinkButton: React.FC<NavbarLinkProps> = ({ path, label }) => {
 	const router = useRouter();
 	const theme: typeof defaultTheme = useTheme();
 	const activeLinkStyle = `
@@ -47,7 +51,7 @@ const LinkToDataDictionary: React.ComponentType = () => {
 				border-right: 2px solid ${theme.colors.white};
 			`}
 		>
-			<Link path={DATA_DICTIONARY_PATH}>
+			<Link path={path}>
 				<a
 					css={(theme) => css`
 						display: flex;
@@ -58,14 +62,14 @@ const LinkToDataDictionary: React.ComponentType = () => {
 						text-decoration: none;
 						color: ${theme.colors.accent_dark};
 						cursor: pointer;
-						${router.pathname === DATA_DICTIONARY_PATH ? activeLinkStyle : ''}
+						${router.pathname === path ? activeLinkStyle : ''}
 					`}
 				>
-					Data Dictionary
+					{label}
 				</a>
 			</Link>
 		</div>
 	);
 };
 
-export default LinkToDataDictionary;
+export default NavbarLinkButton;


### PR DESCRIPTION
# Pull Request

## Description

Refactored `LinkToDataDictionary` into a reusable link component and replaced the hardcoded navbar link with it for improved consistency and maintainability.

Fixes # (234)

## Type of change

Please choose only the relevant options and remove the others.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Verify that the button appears correctly on the navigation bar
- [X] Link the button to the data dictionary page with the correct url
- [X] Link the button to the data explorer page with the correct url

## Checklist:

You do not need to fullfill all requirements of this checklist, select all that apply:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Additional context

Add any other context or screenshots about the pull request here.