### PR TITLE
Bug: Fix Histogram Keys

### DIFF
--- a/components/pages/explorer/BamTable/index.tsx
+++ b/components/pages/explorer/BamTable/index.tsx
@@ -206,7 +206,7 @@ const BamTable = ({ file }: { file?: FileTableData }) => {
 											key={key}
 										>
 											<IobioPanel>
-												<IobioLabelInfoButton key={key} />
+												<IobioLabelInfoButton bamKey={key} />
 												<IobioHistogram brokerKey={key} ignoreOutliers={isOutlierKey(key)} />
 											</IobioPanel>
 										</div>


### PR DESCRIPTION
## Summary

Corrects use of `key` prop to `bamKey` for Histogram elements

## Issues

## Description of Changes
Fixes Histogram labels and pop up info modal text

## Readiness Checklist

- [ ] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [ ] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
